### PR TITLE
Fix lead's note save action

### DIFF
--- a/sql/llx_lead.sql
+++ b/sql/llx_lead.sql
@@ -31,6 +31,7 @@ description 		text,
 note_public 		text,
 note_private 		text,
 fk_user_author		integer	NOT NULL,
+fk_user_modif 		integer NOT NULL DEFAULT 0,
 datec			datetime  NOT NULL,
 fk_user_mod 		integer NOT NULL,
 tms 			timestamp NOT NULL

--- a/sql/update.sql
+++ b/sql/update.sql
@@ -9,3 +9,4 @@ UPDATE llx_c_lead_status SET position='40' , percent='60' WHERE code='NEGO';
 UPDATE llx_c_lead_status SET position='50' , percent='50' WHERE code='PENDING';
 UPDATE llx_c_lead_status SET position='60' , percent='100' WHERE code='WIN';
 UPDATE llx_c_lead_status SET position='70' , percent='0' WHERE code='LOST';
+ALTER TABLE llx_lead ADD COLUMN fk_user_modif integer AFTER `fk_user_author`;


### PR DESCRIPTION
Adding fk_user_modif col to llx_lead to prevent error on lead's note save action.