### PR TITLE
Fix linked file upload

### DIFF
--- a/lead/document.php
+++ b/lead/document.php
@@ -71,7 +71,16 @@ if ($id > 0) {
 /*
  * Actions
  */
-include_once DOL_DOCUMENT_ROOT . '/core/tpl/document_actions_pre_headers.tpl.php';
+
+if((float)DOL_VERSION < 4)
+{
+	include_once DOL_DOCUMENT_ROOT . '/core/tpl/document_actions_pre_headers.tpl.php';
+}
+else
+{
+	include_once DOL_DOCUMENT_ROOT . '/core/actions_linkedfiles.inc.php';
+}
+
 
 
 /*


### PR DESCRIPTION
Petit fix de compatibilité Dolibarr > 3.9

le fichier _"document_actions_pre_headers.tpl.php"_ a disparue à partir de dolibarr 4.0 au profit de _"actions_linkedfiles.inc.php"_