### PR TITLE
2.0 fix tk12269 set precision y

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 English Lead ChangeLog
 
+***** ChangeLog for 2.2 compared to 2.1.7 *****
+FIX : delete "setPrecisionY" function
+
 ***** ChangeLog for 2.0 compared to 1.16 *****
 NEW : Better management of close or open leads 
 

--- a/core/modules/modLead.class.php
+++ b/core/modules/modLead.class.php
@@ -62,7 +62,7 @@ class modLead extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module Lead";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '3.0.0';
+		$this->version = '2.2.0';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/core/modules/modLead.class.php
+++ b/core/modules/modLead.class.php
@@ -62,7 +62,7 @@ class modLead extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module Lead";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '2.1.7';
+		$this->version = '3.0.0';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/index.php
+++ b/index.php
@@ -120,7 +120,8 @@ if (empty($mesg)) {
 						220
 				)
 		));
-		if(function_exists('SetPrecisionY')) $px->SetPrecisionY(0);
+		if(function_exists('SetPrecisionY'));
+		$px->SetPrecisionY(0);
 		$px->SetLegend($legend);
 		$px->setShowLegend(0);
 		$px->setShowPointValue($showpointvalue);

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/dolgraph.class.php';
 require_once 'lib/lead.lib.php';
 
 require_once './class/leadstats.class.php';
-	
+
 // Security check
 if (! $user->rights->lead->read)
 	accessforbidden();
@@ -120,7 +120,7 @@ if (empty($mesg)) {
 						220
 				)
 		));
-		$px->SetPrecisionY(0);
+		if(function_exists('SetPrecisionY')) $px->SetPrecisionY(0);
 		$px->SetLegend($legend);
 		$px->setShowLegend(0);
 		$px->setShowPointValue($showpointvalue);
@@ -165,6 +165,8 @@ $filenamenb = $conf->lead->dir_output . "/stats/leadbystatus.png";
 $fileurlnb = DOL_URL_ROOT . '/viewimage.php?modulepart=leadstats&amp;file=leadbystatus.png';
 $px = new DolGraph();
 $mesg = $px->isGraphKo();
+
+
 if (empty($mesg)) {
 	$i=0;$tot=count($data1);$legend=array();
 	while ($i <= $tot)
@@ -184,8 +186,8 @@ if (empty($mesg)) {
 						220
 				)
 		));
-		$px->SetPrecisionY(0);
-		$px->SetLegend($legend);
+
+		if(function_exists('SetPrecisionY')) $px->SetPrecisionY(0);
 		$px->setShowLegend(0);
 		$px->setShowPointValue($showpointvalue);
 		$px->setShowPercent(1);
@@ -225,7 +227,7 @@ $mesg = $px1->isGraphKo();
 if (! $mesg)
 {
 	$px1->SetData($data);
-	$px1->SetPrecisionY(0);
+	if(function_exists('SetPrecisionY')) $px->SetPrecisionY(0);
 	$i=$startyear;$legend=array();
 	while ($i <= $endyear)
 	{
@@ -239,7 +241,7 @@ if (! $mesg)
 	$px1->SetYLabel($langs->trans("LeadNbLead"));
 	$px1->SetShading(3);
 	$px1->SetHorizTickIncrement(1);
-	$px1->SetPrecisionY(0);
+	if(function_exists('SetPrecisionY')) $px->SetPrecisionY(0);
 	$px1->mode='depth';
 	$px1->SetTitle($langs->trans("LeadNbLeadByMonth"));
 
@@ -273,7 +275,7 @@ if (! $mesg)
 	$px2->SetYLabel($langs->trans("LeadAmountOfLead"));
 	$px2->SetShading(3);
 	$px2->SetHorizTickIncrement(1);
-	$px2->SetPrecisionY(0);
+	if(function_exists('SetPrecisionY')) $px->SetPrecisionY(0);
 	$px2->mode='depth';
 	$px2->SetTitle($langs->trans("LeadAmountOfLeadsByMonth"));
 
@@ -307,7 +309,7 @@ if (! $mesg)
 	$px3->SetYLabel($langs->trans("LeadTransRateOfLead"));
 	$px3->SetShading(3);
 	$px3->SetHorizTickIncrement(1);
-	$px3->SetPrecisionY(0);
+	if(function_exists('SetPrecisionY')) $px3->SetPrecisionY(0);
 	$px3->mode='depth';
 	$px3->SetTitle($langs->trans("LeadTransRateOfLeadsByMonth"));
 


### PR DESCRIPTION
#2.0 fix tk12269 setPrecisionY() function

En Mars 2020 la fonction "setPrecisionY" a été supprimée. Cette fonction avait pour but de modifier la valeur du champs "PositionY" de la classe Dolgraph mais ce champs a été aussi supprimé. Un commit de Laurent supprime toutes les occurences de cette fonction (5675e7c50e95361c18c49adc7374a0ecc31ad690#diff-dda821fa7a76cd49b095756e5992a360ca27a0d8a0705cbdfd2ec04648038e52).

Pour que le module soit compatible avec toutes les versions, je rajoute un "function_exists()" par sécurité.