### PR TITLE
FIX implode function parameter order

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+
 ## Version 2.3
+- FIX : change parameters order for implode function (deprecated since PHP 7.4) - *08/11/2023* - 2.3.20
 - FIX : protected field to public field in lead.class - *19/05/2023* - 2.3.19
 - FIX : Fix box display with access control - *05/06/2023* - 2.3.18
 - FIX : Compat v17 - *04/04/2023* - 2.3.17

--- a/class/actions_lead.class.php
+++ b/class/actions_lead.class.php
@@ -82,7 +82,7 @@ class ActionsLead // extends CommonObject
 					'so.rowid' => ($object->fk_soc ? $object->fk_soc : $object->socid)
 			);
 			if (count($array_exclude_lead) > 0) {
-				$filter['t.rowid !IN'] = implode($array_exclude_lead, ',');
+				$filter['t.rowid !IN'] = implode(',', $array_exclude_lead);
 			}
 			$selectList = $formlead->select_lead('', 'leadid', 1, $filter);
 			if (! empty($selectList) && (count($lead->doclines) == 0  || ($object->table_element=='contrat' && !empty($conf->global->LEAD_ALLOW_MULIPLE_LEAD_ON_CONTRACT)))) {

--- a/core/modules/modLead.class.php
+++ b/core/modules/modLead.class.php
@@ -65,7 +65,7 @@ class modLead extends DolibarrModules
 		$this->description = "Description of module Lead";
 		// Possible values for version are: 'development', 'experimental' or version
 
-		$this->version = '2.3.19';
+		$this->version = '2.3.20';
 
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)


### PR DESCRIPTION
- FIX : change parameters order for implode function (deprecated since PHP 7.4) 
