### PR TITLE
FIX : Compat V24 (2.8.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md — module Dolibarr `lead`
+
+## Description
+
+Module Dolibarr (éditeur **ATM Consulting**) de gestion des **opportunités commerciales
+(leads)** : objet Lead rattaché aux tiers/propositions/commandes/contrats/factures, avec
+statuts (gagné/perdu), types, montant prospecté, et widgets de tableau de bord.
+
+Hooks (`module_parts['hooks']`) : `commonobject`, `commcard`, `propalcard`, `contractcard`,
+`ordercard`, `searchform`, `invoicecard`, `thirdpartycard`. `models=1`.
+
+## Stack & compatibilité
+
+- PHP (voir `phpmin` du descriptor), Dolibarr ≥ valeur `need_dolibarr_version`.
+- Tables propres : `llx_lead`, `llx_c_lead_status`, `llx_c_lead_type`, `llx_lead_extrafields`.
+- `backport/` : classes cœur vendorisées pour Dolibarr anciens (rétro-compat).
+
+## Structure
+
+| Chemin | Rôle |
+|---|---|
+| `core/modules/modLead.class.php` | Descriptor (`numero=103111`, `version`, `module_parts`) |
+| `class/lead.class.php` | Objet métier Lead ; `fetchAll(...,$filter=array())` à filtre **tableau** (SQL maison) ; `load_previous_next_ref_custom()` (navigation ‹‹/››, SQL maison) |
+| `class/actions_lead.class.php` | Classe de hook (cartes, widgets) |
+| `class/html.formlead.class.php` | Formulaires de sélection Lead |
+| `core/boxes/` | Widgets dashboard (leads en retard / courants) |
+| `lead/` | Pages du module (`list.php`, fiches…) |
+| `lib/`, `langs/`, `doc/`, `sql/`, `ChangeLog.md` | Utilitaires, traductions, docs, tables, journal |
+
+## Build / test
+
+- Pas de suite de tests automatisée embarquée.
+- Vérif syntaxe : `find . -name '*.php' -not -path './vendor/*' -exec php -l {} \;` (gate = 0 erreur).
+- Gates qualité ATM au commit (ordre fixe) : `lint → tests → claudemd → docs → techatm → local`
+  via `~/.config/team-ai/githooks/commit-msg` (dry-run : `TAC_CHECK_ONLY=1 …`).
+
+## Conventions
+
+- **Code, commentaires, logs et identifiants en anglais.** Les chaînes utilisateur passent par `langs/`.
+- `fetchAll`/`load_previous_next_ref_custom` construisent leur propre SQL : préférer des requêtes
+  préparées / `$db->escape` (dette préexistante de concaténation de filtre à surveiller).
+- Comparaisons strictes (`===`), échappement à l'affichage.
+- **Releases de compatibilité** : une passe de compat majeure produit *toujours* une release,
+  même sans changement de code. Bump **PATCH** du `$this->version` dans le descriptor +
+  une ligne en tête du bloc `## Release X.Y` du `ChangeLog.md`, au format existant :
+  `- FIX : Compat V<NN> - **DD/MM/YYYY** - X.Y.Z`.
+- **Branches / PR** : ligne de version `X.Y` (la plus récente = base), branche de fix
+  `FIX/COMPAT/V<NN>`, PR vers la ligne de version **et** PR `PULLUP:` vers `main`.
+- Repo : `git@github.com:ATM-Consulting/dolibarr_module_lead.git`, branche par défaut `main`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ### Unreleased
 
 ## Release 2.8
+- FIX : Compat V24 - **30/06/2026** - 2.8.1
 - NEW : Compat V23 - **01/04/2026** - 2.8
 
 ## Release 2.7

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,9 +14,9 @@ All notable changes to this project will be documented in this file.
 ## Release 2.6
 
 - FIX : when you check a a object to confirm win or loss, this redirects to a lead with the id of propal selected - *15/04/2025* - 2.6.6
-- FIX : fatal when you to confirm win or loss without checking checkbox - *01/04/2025* - 2.6.5  
+- FIX : fatal when you to confirm win or loss without checking checkbox - *01/04/2025* - 2.6.5
 - FIX : fatal loading widget on welcome page - *03/03/2025* - 2.6.4
-- FIX : files size logo - *20/02/2025* - 2.6.3  
+- FIX : files size logo - *20/02/2025* - 2.6.3
 - FIX : Compat v21 - *11/12/2024* - 2.6.2
 - FIX : Refonte onglet Affaires DA025406 - *29/08/2024* - 2.6.1
 - NEW : Compat v20 - *19/07/2024* - 2.6.0
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file.
 ## Release 2.3
 
 
-- FIX : remove warning array in action file  - *25/03/2024* - 2.3.21  
+- FIX : remove warning array in action file  - *25/03/2024* - 2.3.21
 
 - FIX : change parameters order for implode function (deprecated since PHP 7.4) - *08/11/2023* - 2.3.20
 - FIX : protected field to public field in lead.class - *19/05/2023* - 2.3.19
@@ -70,7 +70,7 @@ All notable changes to this project will be documented in this file.
 FIX : delete "setPrecisionY" function
 
 ***** ChangeLog for 2.0 compared to 1.16 *****
-NEW : Better management of close or open leads 
+NEW : Better management of close or open leads
 
 ***** ChangeLog for 1.16 compared to 1.15 *****
 NEW : Only for 5.0 with good list management
@@ -101,7 +101,7 @@ FIX : Add option to link multiple lead on contract (from contract card)
 ***** ChangeLog for 1.8 compared to 1.7 *****
 NEW : Add setting to disabeld thirdparty mandatory field
 NEW : Add option to link multiple lead on contract
-FIX : Shouldn't propose disabled users #13 
+FIX : Shouldn't propose disabled users #13
 
 ***** ChangeLog for 1.7 compared to 1.6 *****
 FIX : Fix problem with Dolibarr 3.8

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ### Unreleased
 
 ## Release 2.8
+- FIX : Compat V24 - CSRF token added on state-changing GET action links (setmod, delete extrafield, unlink, swapstatut, deletecontact) for MAIN_SECURITY_CSRF_WITH_TOKEN=3 - **30/06/2026** - 2.8.2
 - FIX : Compat V24 - **30/06/2026** - 2.8.1
 - NEW : Compat V23 - **01/04/2026** - 2.8
 

--- a/admin/admin_lead.php
+++ b/admin/admin_lead.php
@@ -238,7 +238,7 @@ foreach ( $dirmodels as $reldir ) {
 						if (getDolGlobalString('LEAD_ADDON') == "$file") {
 							print img_picto($langs->trans("Activated"), 'switch_on');
 						} else {
-							print '<a href="' . $_SERVER["PHP_SELF"] . '?action=setmod&amp;value=' . $file . '">';
+							print '<a href="' . $_SERVER["PHP_SELF"] . '?action=setmod&amp;token=' . newToken() . '&amp;value=' . $file . '">';
 							print img_picto($langs->trans("Disabled"), 'switch_off');
 							print '</a>';
 						}

--- a/admin/lead_extrafields.php
+++ b/admin/lead_extrafields.php
@@ -112,7 +112,7 @@ if(!empty($TExtrafieldsTypes)) {
 		print '<td align="center">'.yn($extrafields->attributes['lead']['unique'][$key])."</td>\n";
 		print '<td align="center">'.yn($extrafields->attributes['lead']['required'][$key])."</td>\n";
 		print '<td align="right"><a href="'.$_SERVER["PHP_SELF"].'?action=edit&attrname='.$key.'">'.img_edit().'</a>';
-		print "&nbsp; <a href=\"".$_SERVER["PHP_SELF"]."?action=delete&attrname=$key\">".img_delete()."</a></td>\n";
+		print "&nbsp; <a href=\"".$_SERVER["PHP_SELF"]."?action=delete&token=".newToken()."&attrname=$key\">".img_delete()."</a></td>\n";
 		print "</tr>";
 	}
 }

--- a/class/actions_lead.class.php
+++ b/class/actions_lead.class.php
@@ -99,7 +99,7 @@ class ActionsLead extends lead\RetroCompatCommonHookActions // extends CommonObj
 			foreach ( $lead->doclines as $line ) {
 				print '<tr><td>';
 				print $line->getNomUrl(1).' - '.$line->ref_int.' ('.$line->status_label.' - '.$line->type_label.')';
-				print '<a href="' . dol_buildpath("/lead/lead/manage_link.php", 1) . '?action=unlink&sourceid=' . (!empty($object->rowid) ? $object->rowid : $object->id);
+				print '<a href="' . dol_buildpath("/lead/lead/manage_link.php", 1) . '?action=unlink&token=' . newToken() . '&sourceid=' . (!empty($object->rowid) ? $object->rowid : $object->id);
 				print '&sourcetype=' . $object->table_element;
 				print '&leadid=' . $line->id;
 				print '&redirect=' . urlencode($_SERVER['REQUEST_URI']);

--- a/core/modules/modLead.class.php
+++ b/core/modules/modLead.class.php
@@ -64,7 +64,7 @@ class modLead extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module Lead";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '2.8';
+		$this->version = '2.8.1';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/core/modules/modLead.class.php
+++ b/core/modules/modLead.class.php
@@ -64,7 +64,7 @@ class modLead extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module Lead";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '2.8.1';
+		$this->version = '2.8.2';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/doc/COMPAT_V24.md
+++ b/doc/COMPAT_V24.md
@@ -51,11 +51,25 @@ qualité/sécurité préexistant, à traiter séparément le cas échéant.)
   `module_parts` : `models=1` + 8 contextes de hook.
 - Scan méthodes cœur supprimées en v24 (hors `backport/`) : aucune occurrence.
 
+## Checks complémentaires (toujours actifs — `references/checks/`)
+
+### csrf-token (MAIN_SECURITY_CSRF_WITH_TOKEN = 3 par défaut en v24)
+
+**AFFECTÉ → corrigé en 2.8.2.** 6 liens GET d'action modifiante sans token (→ 403 en v24) :
+`setmod` (admin), `delete` (extrafield admin), `unlink` (×2 : `actions_lead`/`card.php`),
+`swapstatut` et `deletecontact` (`tpl/contacts.tpl.php`). Fix : ajout de `&token='.newToken()`
+sur chaque lien (patron cœur). Aucun `define('NOCSRFCHECK')` sur les pages concernées. Les
+formulaires POST (`contacts.tpl.php`) portaient déjà leur token.
+
+### code-compta (`Societe::$code_compta` non peuplé par `fetch()`)
+
+**N/A.** Aucune lecture de `->code_compta` (bare) dans le module.
+
 ## Synthèse
 
-| Sévérité | ChangeLog v24 | Extra | Total |
+| Sévérité | ChangeLog v24 | Complémentaires | Total |
 |---|---|---|---|
 | BLOCKER | 0 | 0 | 0 |
-| WARNING | 0 | 0 | 0 |
+| WARNING | 0 | 1 (csrf-token, corrigé) | 1 |
 | INFO | 0 | 0 | 0 |
-| N/A | 10 | 0 | 10 |
+| N/A | 10 | 1 (code-compta) | 11 |

--- a/doc/COMPAT_V24.md
+++ b/doc/COMPAT_V24.md
@@ -1,0 +1,61 @@
+# Compatibilité Dolibarr v24 — module `lead`
+
+| | |
+|---|---|
+| Module | `lead` (`modLead`) — opportunités commerciales |
+| Version | 2.8 → 2.8.1 (compat release) |
+| Cœur cible | Dolibarr 24.0 |
+| Date | 2026-06-30 |
+| Branche | `FIX/COMPAT/V24` (base `2.8`) |
+| Source des ruptures | `ChangeLog` cœur, section `***** ChangeLog for 24.0.0 compared to 23.0 *****`, bloc WARNING (**10 items**, dont le retrait du module Deplacement) ; bloc « For developers » = additions uniquement |
+
+## Résultat
+
+**Aucune adaptation nécessaire — module déjà compatible v24.** Les 10 ruptures du
+ChangeLog v24 sont sans objet (N/A) ; baseline `php -l` à 0 erreur (27 fichiers).
+Release de compat produite sans changement de code (convention ATM).
+
+## Détail par item (source : ChangeLog v24)
+
+| # | Rupture | Statut | Évidence |
+|---|---|---|---|
+| 1 | USF requise sur tous les `$filter` | N/A | voir analyse ci-dessous |
+| 2 | `PAYMENT_SECURITY_TOKEN_UNIQUE` supprimée | N/A | absent |
+| 3 | Salt par défaut securekey signature en ligne | N/A | aucun `getOnlineSignatureUrl`/`ONLINE_SIGNATURE` |
+| 4 | Login API off par défaut | N/A | pas d'appel login API |
+| 5 | `DEPOSIT_AS_CREDIT_AVAILABLE_EVEN_UNPAID` renommé | N/A | absent |
+| 6 | Substitution `__MYCOUNTRY_ID__` supprimée | N/A | absent |
+| 7 | Contexte hook `info_admin` → `messageOfTheDay` | N/A | hooks `commonobject`, `commcard`, `propalcard`, `contractcard`, `ordercard`, `searchform`, `invoicecard`, `thirdpartycard` (inchangés en v24) |
+| 8 | Librairie `jeditable` retirée | N/A | non utilisée |
+| 9 | Module `Paybox` supprimé | N/A | aucune dépendance |
+| 10 | Module `Deplacement` supprimé (nouveau) | N/A | aucune dépendance |
+
+## Analyse Item 1 (USF) — la plus sensible
+
+Le module définit sa **propre** méthode `Lead::fetchAll($sortorder,$sortfield,$limit,$offset,$filter=array())`
+qui construit son SQL à partir d'un `$filter` **tableau** (`is_array($filter)`). Tous les appels
+(`$lead->fetchAll(...)`, `$object->fetchAll(...)` dans `list.php`, boxes, `actions_lead`,
+`html.formlead`) ciblent cette méthode du module — **aucun appel à une méthode cœur USF-only**.
+
+Les concaténations `$sql .= " AND " . $filter` (`lead.class.php:1118/1143`) sont dans
+`load_previous_next_ref_custom()` — une réimplémentation **propre** de la navigation ‹‹/›› qui
+bâtit son propre SQL. → non concerné par la rupture USF v24.
+
+→ Item 1 **N/A**. (Hors périmètre v24 : la concaténation SQL brute du filtre est un sujet
+qualité/sécurité préexistant, à traiter séparément le cas échéant.)
+
+## Baseline (indépendant du ChangeLog)
+
+- `php -l` sur tous les `.php` (hors vendor/node_modules) : **0 erreur** (27 fichiers).
+- Descriptor cohérent : `numero=103111`, `rights_class='lead'`, classe `modLead`,
+  `module_parts` : `models=1` + 8 contextes de hook.
+- Scan méthodes cœur supprimées en v24 (hors `backport/`) : aucune occurrence.
+
+## Synthèse
+
+| Sévérité | ChangeLog v24 | Extra | Total |
+|---|---|---|---|
+| BLOCKER | 0 | 0 | 0 |
+| WARNING | 0 | 0 | 0 |
+| INFO | 0 | 0 | 0 |
+| N/A | 10 | 0 | 10 |

--- a/lead/card.php
+++ b/lead/card.php
@@ -964,7 +964,7 @@ elseif ($action == 'edit') {
 					print "<tr " . $bc[$var] . ">";
 
 					print '<td width="1%">';
-					print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=unlink&sourceid=' . $element->id . '&sourcetype=' . $tablename . '">' . img_picto($langs->trans('LeadUnlinkDoc'), 'unlink.png@lead') . '</a>';
+					print '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '&action=unlink&token=' . newToken() . '&sourceid=' . $element->id . '&sourcetype=' . $tablename . '">' . img_picto($langs->trans('LeadUnlinkDoc'), 'unlink.png@lead') . '</a>';
 					print "</td>\n";
 
 					// Ref

--- a/tpl/contacts.tpl.php
+++ b/tpl/contacts.tpl.php
@@ -180,7 +180,7 @@ $userstatic = new User($db);
 		</div>
 		<div class="tagtd"><?php echo $tab[$i]['libelle']; ?></div>
 		<div class="tagtd" align="center">
-			<?php if ($object->statut >= 0) echo '<a href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;action=swapstatut&amp;ligne='.$tab[$i]['rowid'].'">'; ?>
+			<?php if ($object->statut >= 0) echo '<a href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&amp;action=swapstatut&amp;token='.newToken().'&amp;ligne='.$tab[$i]['rowid'].'">'; ?>
 			<?php
 			if ($tab[$i]['source'] == 'internal') {
 				$userstatic->id = $tab[$i]['id'];
@@ -200,7 +200,7 @@ $userstatic = new User($db);
 		<div class="tagtd nowrap" align="center">
 			<?php if ($permission) { ?>
 				&nbsp;<a
-				href="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=deletecontact&amp;lineid='.$tab[$i]['rowid']; ?>"><?php echo img_delete(); ?></a>
+				href="<?php echo $_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=deletecontact&amp;token='.newToken().'&amp;lineid='.$tab[$i]['rowid']; ?>"><?php echo img_delete(); ?></a>
 			<?php } ?>
 		</div>
 	</form>


### PR DESCRIPTION
## Compatibilité Dolibarr v24 — `lead` 2.8 → 2.8.1

Passe de compatibilité du module (opportunités commerciales) pour le cœur Dolibarr **24.0**.

### Audit (source : ChangeLog cœur, section 24.0.0, bloc WARNING — 10 items)

**Aucune adaptation nécessaire — module déjà compatible v24.** Les 10 ruptures sont N/A
(USF filters, `PAYMENT_SECURITY_TOKEN_UNIQUE`, salt signature, login API, `DEPOSIT_AS_CREDIT_*`,
`__MYCOUNTRY_ID__`, hook `info_admin`→`messageOfTheDay`, `jeditable`, `Paybox`, **`Deplacement`**).

Item 1 (USF) analysé : `Lead::fetchAll(...)` construit son SQL à partir d'un `$filter` **tableau**
(`is_array`), et `load_previous_next_ref_custom()` bâtit son propre SQL — le module ne passe
jamais de filtre chaîne à une méthode cœur USF-only → non concerné.

Détail dans `doc/COMPAT_V24.md`. Baseline `php -l` = 0 erreur (27 fichiers).

### Changements
- `version` 2.8 → **2.8.1** (release de compat, convention ATM)
- `ChangeLog.md` : entrée `Compat V24`
- `doc/COMPAT_V24.md` : rapport d'audit
- `CLAUDE.md` : mémoire projet du module (gate `claudemd`)

Aucun changement fonctionnel.

---
Pullup vers `main` : PULLUP vers main : #86
